### PR TITLE
Do not override permissions for a VO member dir

### DIFF
--- a/lib/vsc/administration/tools.py
+++ b/lib/vsc/administration/tools.py
@@ -37,7 +37,7 @@ def create_stat_directory(path, permissions, uid, gid, posix, override_permissio
     check the permissions and ownership and change if needed.
     """
 
-    created = None
+    created = False
     try:
         statinfo = os.stat(path)
         logging.debug("Path %s found.", path)

--- a/lib/vsc/administration/tools.py
+++ b/lib/vsc/administration/tools.py
@@ -31,7 +31,7 @@ from vsc.utils.mail import VscMail
 mailer = VscMail()
 
 
-def create_stat_directory(path, permissions, uid, gid, posix):
+def create_stat_directory(path, permissions, uid, gid, posix, override_permissions=True):
     """
     Create a new directory if it does not exist and set permissions, ownership. Otherwise,
     check the permissions and ownership and change if needed.
@@ -45,7 +45,7 @@ def create_stat_directory(path, permissions, uid, gid, posix):
         created = posix.make_dir(path)
         logging.info("Created directory at %s" % (path,))
 
-    if created or stat.S_IMODE(statinfo.st_mode) != permissions:
+    if created or (override_permissions and stat.S_IMODE(statinfo.st_mode) != permissions):
         posix.chmod(permissions, path)
         logging.info("Permissions changed for path %s to %s", path, permissions)
     else:

--- a/lib/vsc/administration/vo.py
+++ b/lib/vsc/administration/vo.py
@@ -301,7 +301,8 @@ class VscTier2AccountpageVo(VscAccountPageVo):
             0700,
             int(member.account.vsc_id_number),
             int(member.usergroup.vsc_id_number),
-            self.gpfs
+            self.gpfs,
+            False  # we should not override permissions on an existing dir where users may have changed them
         )
 
     def create_member_data_dir(self, member):

--- a/test/tools.py
+++ b/test/tools.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+#
+# Copyright 2015-2015 Ghent University
+#
+# This file is part of vsc-administration,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/hpcugent/vsc-administration
+#
+# All rights reserved.
+#
+"""
+Tests for vsc.administration.vo
+
+@author: Andy Georges (Ghent University)
+"""
+import mock
+import os
+import stat
+
+from collections import namedtuple
+
+import vsc.filesystem.posix
+
+
+from vsc.administration import tools
+from vsc.administration.tools import create_stat_directory
+
+from vsc.install.testing import TestCase
+
+
+class ToolsTest(TestCase):
+    """
+    Tests for the VO code.
+    """
+    @mock.patch('os.stat')
+    @mock.patch('vsc.filesystem.posix')
+    def test_create_stat_dir_new(self, mock_posix, mock_os_stat):
+        """
+        Test to see what happens if the dir already exists
+        """
+        mock_os_stat.side_effect = OSError('dir not found')
+        mock_posix.make_dir.result_value = True
+        mock_posix.chmod.result_value = None
+
+        test_uid = 2048
+        test_gid = 4096
+        test_path = '/tmp/test'
+        test_permissions = 0711
+
+        create_stat_directory(test_path, test_permissions, test_uid, test_gid, mock_posix, False)
+
+        mock_os_stat.assert_called_with(test_path)
+        mock_posix.make_dir.assert_called_with(test_path)
+        mock_posix.chmod.assert_called_with(test_permissions, test_path)
+        mock_posix.chown.assert_called_with(test_uid, test_gid, test_path)
+
+    @mock.patch('os.stat')
+    @mock.patch('vsc.filesystem.posix')
+    def test_create_stat_dir_existing_no_override_same_id(self, mock_posix, mock_os_stat):
+        """
+        Test to see what happens if the dir already exists
+        """
+
+        test_uid = 2048
+        test_gid = 4096
+        test_path = '/tmp/test'
+        test_permissions = 0711
+
+        Statinfo = namedtuple("Statinfo", ["st_uid", "st_gid"])
+        mock_os_stat.result_value = Statinfo(test_uid, test_gid)
+
+        create_stat_directory(test_path, test_permissions, test_uid, test_gid, mock_posix, False)
+
+        mock_os_stat.assert_called_with(test_path)
+        self.assertFalse(mock_posix.make_dir.called)
+        self.assertFalse(mock_posix.chmod.called)
+
+    @mock.patch('os.stat')
+    @mock.patch('vsc.filesystem.posix')
+    def test_create_stat_dir_existing_no_override_diff_uid(self, mock_posix, mock_os_stat):
+        """
+        Test to see what happens if the dir already exists
+        """
+
+        test_uid = 2048
+        test_gid = 4096
+        test_path = '/tmp/test'
+        test_permissions = 0711
+
+        Statinfo = namedtuple("Statinfo", ["st_uid", "st_gid"])
+        mock_os_stat.result_value = Statinfo(test_uid+1, test_gid)
+
+        create_stat_directory(test_path, test_permissions, test_uid, test_gid, mock_posix, False)
+
+        mock_os_stat.assert_called_with(test_path)
+        self.assertFalse(mock_posix.make_dir.called)
+        mock_posix.chown.assert_called_with(test_uid, test_gid, test_path)
+
+    @mock.patch('os.stat')
+    @mock.patch('vsc.filesystem.posix')
+    def test_create_stat_dir_existing_no_override_diff_gid(self, mock_posix, mock_os_stat):
+        """
+        Test to see what happens if the dir already exists
+        """
+
+        test_uid = 2048
+        test_gid = 4096
+        test_path = '/tmp/test'
+        test_permissions = 0711
+
+        Statinfo = namedtuple("Statinfo", ["st_uid", "st_gid"])
+        mock_os_stat.result_value = Statinfo(test_uid, test_gid+1)
+
+        create_stat_directory(test_path, test_permissions, test_uid, test_gid, mock_posix, False)
+
+        mock_os_stat.assert_called_with(test_path)
+        self.assertFalse(mock_posix.make_dir.called)
+        mock_posix.chown.assert_called_with(test_uid, test_gid, test_path)
+
+    @mock.patch('os.stat')
+    @mock.patch('stat.S_IMODE')
+    @mock.patch('vsc.filesystem.posix')
+    def test_create_stat_dir_existing_override(self, mock_posix, mock_stat_s_imode, mock_os_stat):
+        """
+        Test to see what happens if the dir already exists
+        """
+
+        test_uid = 2048
+        test_gid = 4096
+        test_path = '/tmp/test'
+        test_permissions = 0711
+
+        Statinfo = namedtuple("Statinfo", ["st_uid", "st_gid"])
+        mock_os_stat.result_value = Statinfo(test_uid, test_gid)
+        mock_stat_s_imode.return_value = 0755
+
+        create_stat_directory(test_path, test_permissions, test_uid, test_gid, mock_posix, True)
+
+        mock_os_stat.assert_called_with(test_path)
+        self.assertFalse(mock_posix.make_dir.called)
+        mock_posix.chmod.assert_called_with(test_permissions, test_path)


### PR DESCRIPTION
- users must be able to change permissions there to allow access to the group
- default remains 0700 upon creation of the $VSC_XXX_VO_USER dir
- fixes #13 

Tasks:

- [x] disallow overriding
- [ ] test