### PR TITLE
Add user option to sync_django_ldap and fix group attributes in ldapsync.py

### DIFF
--- a/bin/sync_django_ldap.py
+++ b/bin/sync_django_ldap.py
@@ -110,7 +110,7 @@ def main():
             if not child_dropped:
                 logger.raiseException("Could not drop privileges to any user: %s;" % ', '.join(child_userlist))
 
-            client = AccountpageClient(token=opts.options.access_token, url=opts.options.account_page_url + '/api/')
+            client = AccountpageClient(token=opts.options.access_token, url=opts.options.account_page_url + '/api')
             syncer = LdapSyncer(client)
             last = last_timestamp
             altered_accounts = syncer.sync_altered_accounts(last, opts.options.dry_run)

--- a/lib/vsc/administration/ldapsync.py
+++ b/lib/vsc/administration/ldapsync.py
@@ -27,7 +27,7 @@ from datetime import datetime
 from ldap import LDAPError
 
 from vsc.accountpage.wrappers import mkVscAccount, mkUserGroup, mkGroup, mkVo
-from vsc.config.base import VSC, INSTITUTE_VOS_GENT, INSTITUTE_VOS_BRUSSEL
+from vsc.config.base import VSC, DEFAULT_VOS_ALL
 from vsc.ldap.entities import VscLdapUser, VscLdapGroup
 from vsc.ldap.filters import CnFilter
 from vsc.utils.py2vs3 import ensure_ascii_string
@@ -208,7 +208,7 @@ class LdapSyncer(object):
                 ldap_attributes['dataDirectory'] = [str(vo.data_path)]
                 ldap_attributes['scratchDirectory'] = [str(vo.scratch_path)]
                 # Set institute moderator for main VOs
-                if vo.vsc_id in INSTITUTE_VOS_GENT.values() + INSTITUTE_VOS_BRUSSEL.values():
+                if vo.vsc_id in DEFAULT_VOS_ALL.values():
                     ldap_attributes['moderator'] = VSC_CONFIG.vo_group_mods[group.institute['name']]
                     logging.info("Using VO moderator %s for VO %s", ldap_attributes['moderator'], group.vsc_id)
 

--- a/lib/vsc/administration/ldapsync.py
+++ b/lib/vsc/administration/ldapsync.py
@@ -208,13 +208,13 @@ class LdapSyncer(object):
                 ldap_attributes['dataDirectory'] = [str(vo.data_path)]
                 ldap_attributes['scratchDirectory'] = [str(vo.scratch_path)]
                 # Set institute moderator for main VOs
-                if vo.vsc_id in DEFAULT_VOS_ALL.values():
-                    ldap_attributes['moderator'] = VSC_CONFIG.vo_group_mods[group.institute['name']]
+                if vo.vsc_id in DEFAULT_VOS_ALL:
+                    ldap_attributes['moderator'] = [VSC_CONFIG.vo_group_mods[group.institute['name']]]
                     logging.info("Using VO moderator %s for VO %s", ldap_attributes['moderator'], group.vsc_id)
 
             if not ldap_attributes['moderator']:
                 ldap_attributes['moderator'] = [str(VSC_CONFIG.backup_group_mods[group.institute['name']])]
-                logging.info("Using backup moderator %s for group %s", group_moderators, group.vsc_id)
+                logging.info("Using backup moderator %s for group %s", ldap_attributes['moderator'], group.vsc_id)
 
             logging.debug("Proposed changes for group %s: %s", group.vsc_id, ldap_attributes)
 

--- a/lib/vsc/administration/ldapsync.py
+++ b/lib/vsc/administration/ldapsync.py
@@ -186,9 +186,13 @@ class LdapSyncer(object):
                 'institute': [institute_name],
                 'gidNumber': ["%d" % (group.vsc_id_number,)],
                 'moderator': group_moderators,
-                'memberUid': [str(a) for a in group.members],
                 'status': [str(group.status)],
             }
+
+            # Only set memberUid if there are actually active members in the group
+            # LDAP addition of records with empty memberUid will fail
+            if group.members:
+                ldap_attributes['memberUid'] = [str(a) for a in group.members]
 
             # VO attributes
             try:

--- a/lib/vsc/administration/ldapsync.py
+++ b/lib/vsc/administration/ldapsync.py
@@ -200,7 +200,7 @@ class LdapSyncer(object):
             except HTTPError as err:
                 # if a 404 occured, the group is not an VO, so we skip this. Otherwise something else went wrong.
                 if err.code != 404:
-                    logger.raiseException("Retrieval of group VO failed for unexpected reasons")
+                    logging.raiseException("Retrieval of group VO failed for unexpected reasons")
             else:
                 # Group is a VO
                 ldap_attributes['fairshare'] = ["%d" % (vo.fairshare,)]

--- a/lib/vsc/administration/ldapsync.py
+++ b/lib/vsc/administration/ldapsync.py
@@ -189,8 +189,10 @@ class LdapSyncer(object):
                 'status': [str(group.status)],
             }
 
-            # Only set memberUid if there are actually active members in the group
-            # LDAP addition of records with empty memberUid will fail
+            # Only set memberUid if there are actually any members in the group
+            # Addition of new group records in LDAP will fail with empty memberUid
+            # Existing LDAP records of groups that become empty will lose memberUid
+            # ldap.modlist.modifyModlist (vsc-ldap) will delete any attributes that are missing in the new record
             if group.members:
                 ldap_attributes['memberUid'] = [str(a) for a in group.members]
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from vsc.install import shared_setup
 from vsc.install.shared_setup import ag, jt
 
 PACKAGE = {
-    'version': '2.3.0',
+    'version': '2.3.1',
     'author': [ag, jt],
     'maintainer': [ag, jt],
     'tests_require': ['mock'],

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ PACKAGE = {
     'install_requires': [
         'vsc-accountpage-clients >= 2.0.0',
         'vsc-base >= 3.0.6',
-        'vsc-config >= 3.0.0',
+        'vsc-config >= 3.3.3',
         'vsc-filesystems >= 1.0.1',
         'pytz',
         'python-ldap',


### PR DESCRIPTION
This PR adds a list of tentative user names to use for the child processes of `sync_django_ldap`. The host system will not necessarily have the `apache` user, as `sync_django_ldap` can be used to sync with a remote django.