### PR TITLE
Use same logic as in user sync for usergroups

### DIFF
--- a/lib/vsc/administration/ldapsync.py
+++ b/lib/vsc/administration/ldapsync.py
@@ -110,7 +110,11 @@ class LdapSyncer(object):
 
         for account in sync_accounts:
             try:
-                usergroup = mkUserGroup(self.client.account[account.vsc_id].usergroup.get()[1])
+                if account.person.institute_login in ('x_admin', 'admin', 'voadmin'):
+                    # TODO to be removed when magic site admin usergroups are purged from code
+                    usergroup = mkGroup((self.client.group[account.vsc_id].get())[1])
+                else:
+                    usergroup = mkUserGroup(self.client.account[account.vsc_id].usergroup.get()[1])
             except HTTPError:
                 logging.error("No corresponding UserGroup for user %s" % (account.vsc_id,))
                 continue

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from vsc.install import shared_setup
 from vsc.install.shared_setup import ag, jt
 
 PACKAGE = {
-    'version': '2.4.0',
+    'version': '2.4.1',
     'author': [ag, jt],
     'maintainer': [ag, jt],
     'tests_require': ['mock'],


### PR DESCRIPTION
For historic reason it seems like some account don't have a 'real'
usergroup. In the account sync there is logic to handle this case but
not in the ldap sync. Now we use the same logic in both points.

I could split if off in a seperate function?

@itkovian please have a look.

@backelj this should help for your problem.