### PR TITLE
Handle the case where a user has no HOME or DATA quota 

### DIFF
--- a/bin/account_rest_quota.py
+++ b/bin/account_rest_quota.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2014-2020 Ghent University
+# Copyright 2014-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/create_tier2_ugent_home_data_directory_tree.py
+++ b/bin/create_tier2_ugent_home_data_directory_tree.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2012-2020 Ghent University
+# Copyright 2012-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/replicate_scratch_tree.py
+++ b/bin/replicate_scratch_tree.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2013-2020 Ghent University
+# Copyright 2013-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/sync_django_ldap.py
+++ b/bin/sync_django_ldap.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: latin-1 -*-
 #
-# Copyright 2013-2020 Ghent University
+# Copyright 2013-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/sync_slurm_acct.py
+++ b/bin/sync_slurm_acct.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2013-2020 Ghent University
+# Copyright 2013-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/sync_vsc_email_postfix.py
+++ b/bin/sync_vsc_email_postfix.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2013-2020 Ghent University
+# Copyright 2013-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/sync_vsc_users.py
+++ b/bin/sync_vsc_users.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2013-2020 Ghent University
+# Copyright 2013-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: latin-1 -*-
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/administration/__init__.py
+++ b/lib/vsc/administration/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: latin-1 -*-
 #
-# Copyright 2012-2020 Ghent University
+# Copyright 2012-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/administration/ldapsync.py
+++ b/lib/vsc/administration/ldapsync.py
@@ -1,6 +1,6 @@
 # -*- coding: latin-1 -*-
 #
-# Copyright 2013-2020 Ghent University
+# Copyright 2013-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/administration/slurm/__init__.py
+++ b/lib/vsc/administration/slurm/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Ghent University
+# Copyright 2015-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/administration/slurm/sync.py
+++ b/lib/vsc/administration/slurm/sync.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2020 Ghent University
+# Copyright 2013-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/administration/tools.py
+++ b/lib/vsc/administration/tools.py
@@ -1,6 +1,6 @@
 # -*- coding: latin-1 -*-
 #
-# Copyright 2012-2020 Ghent University
+# Copyright 2012-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/administration/user.py
+++ b/lib/vsc/administration/user.py
@@ -209,6 +209,7 @@ class VscTier2AccountpageUser(VscAccountPageUser):
 
         # Non-UGent users who have quota in Gent, e.g., in a VO, should not have these set
         if self.person.institute['name'] == self.host_institute:
+            # next(iter(a_list), None) will return the first item of a_list if the list is non-empty, other None
             self._cache['quota']['home'] = next(iter([q.hard for q in institute_quota
                                                       if user_proposition(q, HOME_KEY)]), None)
             self._cache['quota']['data'] = next(iter([q.hard for q in institute_quota

--- a/lib/vsc/administration/user.py
+++ b/lib/vsc/administration/user.py
@@ -1,6 +1,6 @@
 # -*- coding: latin-1 -*-
 #
-# Copyright 2012-2020 Ghent University
+# Copyright 2012-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/administration/user.py
+++ b/lib/vsc/administration/user.py
@@ -209,10 +209,11 @@ class VscTier2AccountpageUser(VscAccountPageUser):
 
         # Non-UGent users who have quota in Gent, e.g., in a VO, should not have these set
         if self.person.institute['name'] == self.host_institute:
-            self._cache['quota']['home'] = [q.hard for q in institute_quota if user_proposition(q, HOME_KEY)][0]
-            self._cache['quota']['data'] = [q.hard for q in institute_quota
+            self._cache['quota']['home'] = next(iter([q.hard for q in institute_quota
+                                                      if user_proposition(q, HOME_KEY)]), None)
+            self._cache['quota']['data'] = next(iter([q.hard for q in institute_quota
                                             if user_proposition(q, DATA_KEY) and not
-                                            q.storage['name'].endswith(STORAGE_SHARED_SUFFIX)][0]
+                                            q.storage['name'].endswith(STORAGE_SHARED_SUFFIX)]), None)
             self._cache['quota']['scratch'] = [q for q in institute_quota if user_proposition(q, SCRATCH_KEY)]
         else:
             self._cache['quota']['home'] = None

--- a/lib/vsc/administration/vo.py
+++ b/lib/vsc/administration/vo.py
@@ -1,6 +1,6 @@
 # -*- coding: latin-1 -*-
 #
-# Copyright 2012-2020 Ghent University
+# Copyright 2012-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if sys.version_info < (3, 0):
     install_requires.append('enum34')
 
 PACKAGE = {
-    'version': '2.4.3',
+    'version': '2.4.4',
     'author': [ag, jt],
     'maintainer': [ag, jt],
     'tests_require': ['mock'],

--- a/test/00-import.py
+++ b/test/00-import.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2020 Ghent University
+# Copyright 2018-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2020 Ghent University
+# Copyright 2018-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/ldapsync.py
+++ b/test/ldapsync.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Ghent University
+# Copyright 2015-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/slurm.py
+++ b/test/slurm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Ghent University
+# Copyright 2015-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/sync_vsc_email.py
+++ b/test/sync_vsc_email.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2020 Ghent University
+# Copyright 2013-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/user.py
+++ b/test/user.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Ghent University
+# Copyright 2015-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/user.py
+++ b/test/user.py
@@ -472,11 +472,17 @@ class VscTier2AccountpageUserTest(TestCase):
                 accountpageuser.user_data_quota,
                 [q['hard'] for q in quota if q['storage']['name'] == 'VSC_DATA' and q['fileset'] == fileset][0]
             )
+            self.assertEqual(
+                [(q.fileset, q.hard, q.storage['name']) for q in accountpageuser.user_scratch_quota],
+                [(q['fileset'], q['hard'], q['storage']['name']) for q in quota
+                    if q['storage']['storage_type'] == 'scratch' and q['fileset'] == fileset]
+            )
 
         # check if no home or data quota are set
         accountpageuser = set_up_accountpageuser(test_account_3, test_quota_3, BRUSSEL)
         self.assertEqual(accountpageuser.user_home_quota, None)
         self.assertEqual(accountpageuser.user_data_quota, None)
+        self.assertNotEqual(accountpageuser.user_scratch_quota, None)
 
 
 class UserDeploymentTest(TestCase):

--- a/test/vo.py
+++ b/test/vo.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Ghent University
+# Copyright 2015-2021 Ghent University
 #
 # This file is part of vsc-administration,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),


### PR DESCRIPTION
Some special users (like our install user) have no quota set on
VSC_HOME. This causes failures if this script runs and something in that
account changed.

