### PR TITLE
Drop duplicate 'institute' optionsin slurm sync

### DIFF
--- a/bin/sync_slurm_acct.py
+++ b/bin/sync_slurm_acct.py
@@ -80,7 +80,6 @@ def main():
             None,
         ),
         'start_timestamp': ('Timestamp to start the sync from', str, 'store', None),
-        'institute': ('The name of the local institute for which to sync', str, 'store', GENT),
     }
 
     opts = ExtendedSimpleOption(options)
@@ -113,7 +112,7 @@ def main():
         sacctmgr_commands += slurm_institute_accounts(slurm_account_info, clusters, host_institute)
 
         # All users belong to a VO, so fetching the VOs is necessary/
-        account_page_vos = [mkVo(v) for v in client.vo.institute[opts.options.institute].get()[1]]
+        account_page_vos = [mkVo(v) for v in client.vo.institute[opts.options.host_institute].get()[1]]
 
         # The VOs do not track active state of users, so we need to fetch all accounts as well
         active_accounts = set([a["vsc_id"] for a in client.account.get()[1] if a["isactive"]])

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if sys.version_info < (3, 0):
     install_requires.append('enum34')
 
 PACKAGE = {
-    'version': '2.4.4',
+    'version': '2.4.5',
     'author': [ag, jt],
     'maintainer': [ag, jt],
     'tests_require': ['mock'],


### PR DESCRIPTION
We managed to get two options for 'institute' in the slurm sync. Reduce
it back to one.

Don't merge until #111 is merged.