### PR TITLE
fix for slurm 21.08

### DIFF
--- a/lib/vsc/administration/slurm/sync.py
+++ b/lib/vsc/administration/slurm/sync.py
@@ -51,7 +51,7 @@ IGNORE_ACCOUNTS = ["root"]
 SacctUserFields = ["User", "Def_Acct", "Admin", "Cluster", "Account", "Partition", "Share",
                    "MaxJobs", "MaxNodes", "MaxCPUs", "MaxSubmit", "MaxWall", "MaxCPUMins",
                    "QOS", "Def_QOS"]
-SacctAccountFields = ["Account", "Descr", "Org", "Cluster", "Par_Name", "User", "Share",
+SacctAccountFields = ["Account", "Descr", "Org", "Cluster", "ParentName", "User", "Share",
                       "GrpJobs", "GrpNodes", "GrpCPUs", "GrpMem", "GrpSubmit", "GrpWall", "GrpCPUMins",
                       "MaxJobs", "MaxNodes", "MaxCPUs", "MaxSubmit", "MaxWall", "MaxCPUMins",
                       "QOS", "Def_QOS"]


### PR DESCRIPTION
do NOT merge this unless you want to use slurm 21.08

I've opened this to not forgot about it. I guess the only 'real' solution is to version the fields per slurm version?