### PR TITLE
Enhance job cancel commands on a per-user basis

### DIFF
--- a/bin/sync_slurm_acct.py
+++ b/bin/sync_slurm_acct.py
@@ -39,7 +39,7 @@ NAGIOS_CHECK_INTERVAL_THRESHOLD = 60 * 60  # 60 minutes
 SYNC_TIMESTAMP_FILENAME = "/var/cache/%s.timestamp" % (NAGIOS_HEADER)
 SYNC_SLURM_ACCT_LOGFILE = "/var/log/%s.log" % (NAGIOS_HEADER)
 
-MAX_USERS_JOB_CANCEL = 30
+MAX_USERS_JOB_CANCEL = 10
 
 class SyncSanityError(Exception):
     pass

--- a/lib/vsc/administration/slurm/sync.py
+++ b/lib/vsc/administration/slurm/sync.py
@@ -816,6 +816,7 @@ def slurm_user_accounts(vo_members, active_accounts, slurm_user_info, clusters, 
         for user in remove_users:
             job_cancel_commands[user].append(create_remove_user_jobs_command(user=user, cluster=cluster))
 
+        # Remove users from the clusters (in all accounts)
         association_remove_commands.extend([
             create_remove_user_command(user=user, cluster=cluster) for user in remove_users
         ])

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
 
 
 PACKAGE = {
-    'version': '3.5.0',
+    'version': '3.6.0',
     'author': [ag, jt],
     'maintainer': [ag, jt],
     'tests_require': ['mock'],

--- a/test/slurm.py
+++ b/test/slurm.py
@@ -146,9 +146,9 @@ class SlurmSyncTestGent(TestCase):
         ]
 
         commands = slurm_project_users_accounts(
-            project_members, 
-            active_accounts, 
-            slurm_user_info, 
+            project_members,
+            active_accounts,
+            slurm_user_info,
             ["mycluster"],
             default_account="default_account",
             protected_accounts=("protected_account1", "protected_acocunt2")
@@ -205,20 +205,22 @@ class SlurmSyncTestGent(TestCase):
             SlurmUser(User='user5', Def_Acct='vo2', Admin='None', Cluster='banette', Account='vo2', Partition='', Share='1', MaxJobs='', MaxNodes='', MaxCPUs='', MaxSubmit='', MaxWall='', MaxCPUMins='', QOS='normal', Def_QOS=''),
         ]
 
-        (job_cancel_commands, commands) = slurm_user_accounts(vo_members, active_accounts, slurm_user_info, ["banette"])
+        (job_cancel_commands, commands, remove_user_commands) = slurm_user_accounts(vo_members, active_accounts, slurm_user_info, ["banette"])
 
         self.assertEqual(set([tuple(x) for x in commands]), set([tuple(x) for x in [
             shlex.split("/usr/bin/sacctmgr -i add user user6 Account=vo2 Cluster=banette DefaultAccount=vo2"),
-            shlex.split("/usr/bin/sacctmgr -i delete user name=user2 Cluster=banette"),
             shlex.split("/usr/bin/sacctmgr -i add user user3 Account=vo1 Cluster=banette"),
-            shlex.split("/usr/bin/sacctmgr -i modify user Name=user3 Cluster=banette set DefaultAccount=vo1"),
-            shlex.split("/usr/bin/sacctmgr -i delete user name=user3 Account=vo2 Cluster=banette"),
             shlex.split("/usr/bin/sacctmgr -i add user user4 Account=vo2 Cluster=banette"),
+            shlex.split("/usr/bin/sacctmgr -i modify user Name=user3 Cluster=banette set DefaultAccount=vo1"),
             shlex.split("/usr/bin/sacctmgr -i modify user Name=user4 Cluster=banette set DefaultAccount=vo2"),
+        ]]))
+        self.assertEqual(set([tuple(x) for x in remove_user_commands]), set([tuple(x) for x in [
+            shlex.split("/usr/bin/sacctmgr -i delete user name=user2 Cluster=banette"),
+            shlex.split("/usr/bin/sacctmgr -i delete user name=user3 Account=vo2 Cluster=banette"),
             shlex.split("/usr/bin/sacctmgr -i delete user name=user4 Account=vo1 Cluster=banette"),
         ]]))
 
-        self.assertEqual(set([tuple(x) for x in job_cancel_commands]), set([tuple(x) for x in [
+        self.assertEqual(set([tuple(x) for c in job_cancel_commands.values() for x in c]), set([tuple(x) for x in [
             shlex.split("/usr/bin/scancel --cluster=banette --user=user2"),
             shlex.split("/usr/bin/scancel --cluster=banette --user=user3 --account=vo2"),
             shlex.split("/usr/bin/scancel --cluster=banette --user=user4 --account=vo1"),


### PR DESCRIPTION
- make sure to add users first
- do not add the cancel commands if there are too many users that would be cancelled
- remove users last (may fail due to cancel commands not being added)