### PR TITLE
don't create scancel commands for users without jobs

### DIFF
--- a/bin/sync_slurm_acct.py
+++ b/bin/sync_slurm_acct.py
@@ -40,8 +40,6 @@ NAGIOS_CHECK_INTERVAL_THRESHOLD = 60 * 60  # 60 minutes
 SYNC_TIMESTAMP_FILENAME = "/var/cache/%s.timestamp" % (NAGIOS_HEADER)
 SYNC_SLURM_ACCT_LOGFILE = "/var/log/%s.log" % (NAGIOS_HEADER)
 
-MAX_USERS_JOB_CANCEL = 10
-
 class SyncSanityError(Exception):
     pass
 
@@ -75,6 +73,7 @@ def main():
             'store',
             [PRODUCTION, PILOT]
         ),
+        'limit_cancel': ('Limit of scancel commands allowed', int, 'store', 10),
         'force': (
             'Force the sync instead of bailing if too many scancel commands would be issues',
             None,
@@ -154,7 +153,7 @@ def main():
         sacctmgr_commands = []
 
         # safety to avoid emptying the cluster due to some error upstream
-        if not opts.options.force and len(job_cancel_commands) > MAX_USERS_JOB_CANCEL:
+        if not opts.options.force and len(job_cancel_commands) > opts.options.limit_cancel:
             logging.warning("Would add commands to cancel jobs for %d users", len(job_cancel_commands))
             logging.debug("Would execute the following cancel commands:")
             for jc in job_cancel_commands.values():

--- a/bin/sync_slurm_acct.py
+++ b/bin/sync_slurm_acct.py
@@ -73,9 +73,16 @@ def main():
             'store',
             [PRODUCTION, PILOT]
         ),
-        'limit_cancel': ('Limit of scancel commands allowed', int, 'store', 10),
-        'force': (
-            'Force the sync instead of bailing if too many scancel commands would be issues',
+        'max_scancel': ('Limit of scancel commands allowed', int, 'store', 20),
+        'max_user_del': ('Limit of user delete commands allowed', int, 'store', 10),
+        'force_scancel': (
+            'Force the sync instead of bailing if too many scancel commands would be issued',
+            None,
+            'store_true',
+            False
+        ),
+        'force_user_del': (
+            'Force the sync instead of bailing if too many user delete commands would be issued',
             None,
             'store_true',
             False
@@ -153,14 +160,23 @@ def main():
         sacctmgr_commands = []
 
         # safety to avoid emptying the cluster due to some error upstream
-        if not opts.options.force and len(job_cancel_commands) > opts.options.limit_cancel:
-            logging.warning("Would add commands to cancel jobs for %d users", len(job_cancel_commands))
+        if not opts.options.force_scancel and len(job_cancel_commands) > (opts.options.max_scancel / len(clusters)):
+            logging.warning("Would add %s scancel commands per cluster", len(job_cancel_commands) / len(clusters))
             logging.debug("Would execute the following cancel commands:")
             for jc in job_cancel_commands.values():
                 logging.debug("%s", jc)
-            raise SyncSanityError("Would cancel jobs for %d users" % len(job_cancel_commands))
+            raise SyncSanityError("Would run %d scancel jobs per cluster" % len(job_cancel_commands) / len(clusters))
 
         sacctmgr_commands += [c for cl in job_cancel_commands.values() for c in cl]
+
+        # safety to avoid removing too many users due to some error upstream
+        max_user_del = opts.options.max_user_del / len(clusters)
+        if not opts.options.force_user_del and len(association_remove_commands) > max_user_del:
+            logging.warning("Would add commands to remove %d users", len(association_remove_commands) / len(clusters))
+            logging.debug("Would execute the following remove commands:")
+            for jc in association_remove_commands:
+                logging.debug("%s", jc)
+            raise SyncSanityError("Would run %d user delete commands per cluster" % (len(association_remove_commands) / len(clusters)))
 
         # removing users may fail, so should be done last
         sacctmgr_commands += association_remove_commands

--- a/lib/vsc/administration/slurm/sacctmgr.py
+++ b/lib/vsc/administration/slurm/sacctmgr.py
@@ -38,6 +38,9 @@ SLURM_ORGANISATIONS = {
 class SacctMgrException(Exception):
     pass
 
+class SacctParseException(Exception):
+    pass
+
 
 class SacctMgrTypes(Enum):
     accounts = "accounts"
@@ -155,7 +158,7 @@ def parse_slurm_sacct_line(header, line, info_type, user_field_number, account_f
     elif info_type == SacctMgrTypes.activejobs:
         creator = mkSlurmActivejobs
     else:
-        return None
+        raise SacctParseException("info_type %s does not exist.", info_type)
 
     return creator(dict(zip(header, fields)))
 

--- a/lib/vsc/administration/slurm/sync.py
+++ b/lib/vsc/administration/slurm/sync.py
@@ -25,7 +25,7 @@ from vsc.administration.slurm.sacctmgr import (
     create_add_account_command, create_remove_account_command,
     create_change_account_fairshare_command,
     create_add_user_command, create_change_user_command, create_remove_user_command, create_remove_user_account_command,
-    create_add_qos_command, create_remove_qos_command, create_modify_qos_command
+    create_add_qos_command, create_remove_qos_command, create_modify_qos_command, get_slurm_sacct_active_jobs_for_user,
     )
 from vsc.administration.slurm.scancel import (
     create_remove_user_jobs_command, create_remove_jobs_for_account_command,

--- a/lib/vsc/administration/slurm/sync.py
+++ b/lib/vsc/administration/slurm/sync.py
@@ -373,7 +373,9 @@ def slurm_user_accounts(vo_members, active_accounts, slurm_user_info, clusters, 
         ])
 
         for user in remove_users:
-            job_cancel_commands[user].append(create_remove_user_jobs_command(user=user, cluster=cluster))
+            active_jobs = get_slurm_sacct_active_jobs_for_user(user)
+            if active_jobs:
+                job_cancel_commands[user].append(create_remove_user_jobs_command(user=user, cluster=cluster))
 
         # Remove users from the clusters (in all accounts)
         association_remove_commands.extend([

--- a/test/slurm_sacctmgr.py
+++ b/test/slurm_sacctmgr.py
@@ -21,7 +21,7 @@ Tests for vsc.administration.slurm.*
 from vsc.install.testing import TestCase
 
 from vsc.administration.slurm.sacctmgr import (
-    parse_slurm_sacct_dump,
+    parse_slurm_sacct_dump, SlurmActivejobs,
     SacctMgrTypes, SlurmAccount, SlurmUser,
     )
 
@@ -69,3 +69,16 @@ class SlurmSacctmgrTest(TestCase):
         ]))
 
 
+
+        sacctmgr_active_jobs_output = [
+            "JobID|JobName|Partition|Account|AllocCPUS|State|ExitCode",
+            "14367800|normal|part1|acc1|1|RUNNING|0:0",
+            "14367800.batch|batch||acc1|1|RUNNING|0:0",
+            "14367800.extern|extern||acc1|1|RUNNING|0:0",
+        ]
+        info = parse_slurm_sacct_dump(sacctmgr_active_jobs_output, SacctMgrTypes.activejobs)
+        self.assertEqual(set(info), set([
+            SlurmActivejobs(JobID='14367800', JobName='normal', Partition='part1', Account='acc1', AllocCPUS='1', State='RUNNING', ExitCode='0:0'),
+            SlurmActivejobs(JobID='14367800.batch', JobName='batch', Partition='', Account='acc1', AllocCPUS='1', State='RUNNING', ExitCode='0:0'),
+            SlurmActivejobs(JobID='14367800.extern', JobName='extern', Partition='', Account='acc1', AllocCPUS='1', State='RUNNING', ExitCode='0:0')
+        ]))

--- a/test/slurm_sacctmgr.py
+++ b/test/slurm_sacctmgr.py
@@ -23,6 +23,7 @@ from vsc.install.testing import TestCase
 from vsc.administration.slurm.sacctmgr import (
     parse_slurm_sacct_dump, SlurmActivejobs,
     SacctMgrTypes, SlurmAccount, SlurmUser,
+    SacctParseException
     )
 
 
@@ -82,3 +83,7 @@ class SlurmSacctmgrTest(TestCase):
             SlurmActivejobs(JobID='14367800.batch', JobName='batch', Partition='', Account='acc1', AllocCPUS='1', State='RUNNING', ExitCode='0:0'),
             SlurmActivejobs(JobID='14367800.extern', JobName='extern', Partition='', Account='acc1', AllocCPUS='1', State='RUNNING', ExitCode='0:0')
         ]))
+
+
+        with self.assertRaises(SacctParseException):
+            parse_slurm_sacct_dump("sacctmgr_active_jobs_output", "doesnotexist")


### PR DESCRIPTION
- make limit of scancel commands configurable
- set limit of amount of user del
- improve logging about the scancel and user del limits
- don't create scancel commands for users that don't exist or don't have any jobs

fixes #127 